### PR TITLE
make compatible with Python 3

### DIFF
--- a/src/esp32ulp_build_recipe.py
+++ b/src/esp32ulp_build_recipe.py
@@ -231,7 +231,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
     else:
         file_names_constant = gen_file_names_constant()
         with open(file_names_constant['sym'],"w") as fsym:
-            fsym.write(out)
+            fsym.write(out.decode('utf-8'))
         console_string += cmd[0] + '\r'
 
     ## Create LD export script and header file
@@ -302,7 +302,7 @@ def gen_assembly(PATHS):
                         ulpcc_files.append(file)
 
     except Exception as e:
-        print e
+        print(e)
 
     for file in ulpcc_files:
         cmd = gen_lcc_cmd(PATHS, file)
@@ -313,7 +313,7 @@ def gen_assembly(PATHS):
             sys.exit(error_string)
         else:
             if out == "":
-                print cmd[0]
+                print(cmd[0])
             else:
                 sys.exit(str(out))
 


### PR DESCRIPTION
This is a very minor change which allows to run on Python 3, while the script should still be compatible with Python 2.

On my Ubuntu 20.10 system I was unable to get it running with Python 2, since Python 2 support has basically been dropped and certain libraries are simply no longer available.