### PR TITLE
Better method for python3 compatibility

### DIFF
--- a/platform.local.txt
+++ b/platform.local.txt
@@ -16,6 +16,10 @@ compiler.c.elf.extra_flags="-L{build.path}/sketch/" -T ulp_main.ld "{build.path}
 ## add ulptool.h to g++
 compiler.cpp.extra_flags="-I{tools.ulptool.path}/include/ulptool"
 
+## copy '.s' (ulp) files
+recipe.hooks.core.prebuild.01.pattern=sh -c 'cp -vp {build.source.path}/*.s {build.path}/sketch/ | sed s,^,ASMFIXUP:,'
+recipe.hooks.core.prebuild.01.pattern.windows=cmd /c if exist "{build.source.path}\*.s" copy /y "{build.source.path}\*.s" "{build.path}\sketch\"
+
 ## compile '.s' (ulp) files
 recipe.hooks.core.postbuild.01.pattern={compiler.s.cmd} {compiler.cpreprocessor.flags} -b {build.path} -p {runtime.platform.path} -u {compiler.ulp.path} -x {compiler.path} -t {tools.ulptool.path} --DF_CPU={build.f_cpu} --DARDUINO={runtime.ide.version} --DARDUINO_={build.board} --DARDUINO_ARCH_={build.arch} --DARDUINO_BOARD="{build.board}" --DARDUINO_VARIANT="{build.variant}"
 

--- a/src/esp32ulp_build_recipe.py
+++ b/src/esp32ulp_build_recipe.py
@@ -124,7 +124,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
 
         ## Run each assembly file (foo.S) through C preprocessor
         cmd = gen_xtensa_preprocessor_cmd(PATHS, file, board_options)
-        proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.STDOUT,shell=False)
+        proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.STDOUT,shell=False,universal_newlines=True)
         (out, err) = proc.communicate()
         if err:
             error_string = cmd[0] + '\r' + err
@@ -134,7 +134,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
 
         ## Run preprocessed assembly sources through assembler
         cmd = gen_binutils_as_cmd(PATHS, file)
-        proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False)
+        proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False,universal_newlines=True)
         (out, err) = proc.communicate()
         if err:
             error_string = cmd[0] + '\r' + err
@@ -144,7 +144,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
 
     ## Run linker script template through C preprocessor
     cmd = gen_xtensa_ld_cmd(PATHS, ulp_sfiles, board_options)
-    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False)
+    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False,universal_newlines=True)
     (out, err) = proc.communicate()
     if err:
         error_string = cmd[0] + '\r' + err
@@ -154,7 +154,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
 
     ## Link object files into an output ELF file
     cmd = gen_binutils_ld_cmd(PATHS, ulp_sfiles)
-    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False)
+    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False,universal_newlines=True)
     (out, err) = proc.communicate()
     if err:
         error_string = cmd[0] + '\r' + err
@@ -164,7 +164,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
 
     ## Get section memory sizes
     cmd = gen_binutils_size_cmd(PATHS)
-    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False)
+    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False,universal_newlines=True)
     (out, err) = proc.communicate()
     if err:
         error_string = cmd[0] + '\r' + err
@@ -223,7 +223,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
 
     ## Generate list of global symbols
     cmd = gen_binutils_nm_cmd(PATHS)
-    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False)
+    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False,universal_newlines=True)
     (out, err) = proc.communicate()
     if err:
         error_string = cmd[0] + '\r' + err
@@ -231,12 +231,12 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
     else:
         file_names_constant = gen_file_names_constant()
         with open(file_names_constant['sym'],"w") as fsym:
-            fsym.write(out.decode('utf-8'))
+            fsym.write(out)
         console_string += cmd[0] + '\r'
 
     ## Create LD export script and header file
     cmd = gen_mapgen_cmd(PATHS)
-    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False)
+    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False,universal_newlines=True)
     (out, err) = proc.communicate()
     if err:
         error_string = cmd[0] + '\r' + err
@@ -246,7 +246,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
 
     ## Add the generated binary to the list of binary files
     cmd = gen_binutils_objcopy_cmd(PATHS)
-    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False)
+    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False,universal_newlines=True)
     (out, err) = proc.communicate()
     if err:
         error_string = cmd[0] + '\r' + err
@@ -256,7 +256,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
 
     ## Add the generated binary to the list of binary files
     cmd = gen_xtensa_objcopy_cmd(PATHS)
-    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False)
+    proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=False,universal_newlines=True)
     (out, err) = proc.communicate()
     if err:
         error_string = cmd[0] + '\r' + err
@@ -275,7 +275,7 @@ def build_ulp(PATHS, ulp_sfiles, board_options, has_s_file):
             file.write(json.dumps(dict_hash))
         ## Run esp32.ld thru the c preprocessor generating esp32_out.ld
         cmd = gen_xtensa_ld_preprocessor_cmd(PATHS)
-        proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.STDOUT,shell=False)
+        proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.STDOUT,shell=False,universal_newlines=True)
         (out, err) = proc.communicate()
         if err:
             error_string = cmd[0] + '\r' + err
@@ -306,7 +306,7 @@ def gen_assembly(PATHS):
 
     for file in ulpcc_files:
         cmd = gen_lcc_cmd(PATHS, file)
-        proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.STDOUT,shell=False)
+        proc = subprocess.Popen(cmd[1],stdout=subprocess.PIPE,stderr=subprocess.STDOUT,shell=False,universal_newlines=True)
         (out, err) = proc.communicate()
         if err:
             error_string = cmd[0] + '\r' + err


### PR DESCRIPTION
https://docs.python.org/2.7/library/subprocess.html#subprocess.Popen.communicate
https://docs.python.org/3.8/library/subprocess.html#subprocess.Popen.communicate
The universal_newlines argument is equivalent to text and is provided for backwards compatibility. By default, file objects are opened in binary mode.

This fixes the `TypeError: can only concatenate str (not "bytes") to str`
(for error_string = cmd[0] + '\r' + err)
 and also the `TypeError: write() argument must be str, not bytes `
(for fsym.write(out))
