### PR TITLE
Fix undefined reference to ulp_count and ulp_entry

### DIFF
--- a/platform.local.txt
+++ b/platform.local.txt
@@ -16,6 +16,10 @@ compiler.c.elf.extra_flags="-L{build.path}/sketch/" -T ulp_main.ld "{build.path}
 ## add ulptool.h to g++
 compiler.cpp.extra_flags="-I{tools.ulptool.path}/include/ulptool"
 
+## copy '.s' (ulp) files
+recipe.hooks.core.prebuild.01.pattern=sh -c 'cp -vp {build.source.path}/*.s {build.path}/sketch/ | sed s,^,ASMFIXUP:,'
+recipe.hooks.core.prebuild.01.pattern.windows=cmd /c if exist "{build.source.path}\*.s" copy /y "{build.source.path}\*.s" "{build.path}\sketch\"
+
 ## compile '.s' (ulp) files
 recipe.hooks.core.postbuild.01.pattern={compiler.s.cmd} {compiler.cpreprocessor.flags} -b {build.path} -p {runtime.platform.path} -u {compiler.ulp.path} -x {compiler.path} -t {tools.ulptool.path} --DF_CPU={build.f_cpu} --DARDUINO={runtime.ide.version} --DARDUINO_={build.board} --DARDUINO_ARCH_={build.arch} --DARDUINO_BOARD="{build.board}" --DARDUINO_VARIANT="{build.variant}"
 


### PR DESCRIPTION
Arduino doesn't seem to be copying the .s files from the sketch directory to the temp directory. This causes the following errors:

`undefined reference to 'ulp_count'`

`undefined reference to 'ulp_entry'`.

See issue #78 