### PR TITLE
Add build hook to copy `.s` files

### DIFF
--- a/platform.local.txt
+++ b/platform.local.txt
@@ -16,6 +16,10 @@ compiler.c.elf.extra_flags="-L{build.path}/sketch/" -T ulp_main.ld "{build.path}
 ## add ulptool.h to g++
 compiler.cpp.extra_flags="-I{tools.ulptool.path}/include/ulptool"
 
+## copy '.s' (ulp) files from sketch to build folder if present
+recipe.hooks.core.postbuild.00.pattern=sh -c 'cd "{build.source.path}" && cp *.s "{build.path}/sketch" || true'
+recipe.hooks.core.postbuild.00.pattern.windows=cmd /C copy {build.source.path}\*.s "{build.path}\sketch" || exit 0
+
 ## compile '.s' (ulp) files
 recipe.hooks.core.postbuild.01.pattern={compiler.s.cmd} {compiler.cpreprocessor.flags} -b {build.path} -p {runtime.platform.path} -u {compiler.ulp.path} -x {compiler.path} -t {tools.ulptool.path} --DF_CPU={build.f_cpu} --DARDUINO={runtime.ide.version} --DARDUINO_={build.board} --DARDUINO_ARCH_={build.arch} --DARDUINO_BOARD="{build.board}" --DARDUINO_VARIANT="{build.variant}"
 


### PR DESCRIPTION
Previously, the project relied on undefined behavior of older versions of the Arduino build system, where correct file extension case was not enforced when copying files from the sketch folder to the build folder, in order to .

This stopped working at Arduino IDE 1.8.14, meaning that users were forced to use a significantly outdated version of the IDE; a requirement which was undocumented.

This is fixed by adding an additional [build hook](https://arduino.github.io/arduino-cli/latest/platform-specification/#pre-and-post-build-hooks-since-arduino-ide-165) to `platform.local.txt` that copies the `.s` files from the sketch folder to the build folder.

Due to limitations of the Arduino platform framework, it was necessary to jump through some hoops to get working patterns for these commands:

- Windows command pattern must use `cmd /C` because `copy` is not directly usable via [the `os/exec` Go package](https://pkg.go.dev/os/exec) that executes the generated commands.
- Linux/macOS command patterns must use `cd` because otherwise the `*.s` glob was broken by being automatically quoted as part of the sketch path.
- Linux/macOS command patters must use `sh -c` because `cd` is not directly usable via the `os/exec` Go package that executes the generated commands.

---

Fixes https://github.com/duff2013/ulptool/issues/74